### PR TITLE
Added lot of options for advanced deployment scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ If you are using a public repository you can start here.
   * __LOG_FILE__: (optional) the full path of file to log all script output
   * __EMAIL_NOTIFICATIONS__: (optional) email address to which a copy of the script output will be sent
   * __TIME_LIMIT__: maximum time allowed for each command, in seconds. 60 should be fine unless your deployments are massive. Adjust if necessary.
+  * __EXCLUDE_FILES__: (optional) array of files or filename patterns which won't be copied to `TARGET_DIR` . By default it's `.git`.
+  * __RSYNC_FLAGS__: (optional) override rsync flags. By default, it's `-rltgoDzvO` .
 
 NOTE: do not include/track the files `deploy-config.php` and `VERSION` in your repository.
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ If you are using a public repository you can start here.
   * __TIME_LIMIT__: maximum time allowed for each command, in seconds. 60 should be fine unless your deployments are massive. Adjust if necessary.
   * __EXCLUDE_FILES__: (optional) array of files or filename patterns which won't be copied to `TARGET_DIR` . By default it's `.git`.
   * __RSYNC_FLAGS__: (optional) override rsync flags. By default, it's `-rltgoDzvO` .
+  * __COMMANDS_BEFORE_RSYNC__: (optional) array of commands executed between pulling remote repository and copying files to target directory. These commands are executed under `GIT_DIR` directory.
+  * __COMMANDS_AFTER_RSYNC__: (optional) array of commands executed after copying files to target directory. These commands are executed under `TARGET_DIR` directory.
 
 NOTE: do not include/track the files `deploy-config.php` and `VERSION` in your repository.
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ If you are using a public repository you can start here.
   * __RSYNC_FLAGS__: (optional) override rsync flags. By default, it's `-rltgoDzvO` .
   * __COMMANDS_BEFORE_RSYNC__: (optional) array of commands executed between pulling remote repository and copying files to target directory. These commands are executed under `GIT_DIR` directory.
   * __COMMANDS_AFTER_RSYNC__: (optional) array of commands executed after copying files to target directory. These commands are executed under `TARGET_DIR` directory.
+  * __CLEANUP_WORK_TREE__: (optional) set to `true` if you want to clean `GIT_DIR` from intermediate files created by custom commands and rebuild project from scratch every time. Does not affect `TARGET_DIR` at all.
 
 NOTE: do not include/track the files `deploy-config.php` and `VERSION` in your repository.
 

--- a/deploy-config.orig.php
+++ b/deploy-config.orig.php
@@ -64,3 +64,21 @@ define('EMAIL_NOTIFICATIONS', '');
 
 /* TIME_LIMIT: Time limit for each command */
 define('TIME_LIMIT', 60);
+
+/* EXCLUDE_FILES: 
+ * Array of files excluded from rsync (they will appear in GIT_DIR, but not in TARGET_DIR)
+ * By default, only .git directory is excluded. 
+ * It's recommended to leave '.git' excluded and add something more if needed.
+ * Example: define('EXCLUDE_FILES', serialize(array('.git', '.gitignore', '*.less', '*.scss')));
+ *
+ */
+define('EXCLUDE_FILES', serialize(array('.git')));
+
+/* RSYNC_FLAGS: 
+ * Custom flags to run rsync with
+ * Default: '-rltgoDzvO'
+ * Do not change them if not necessary
+ * Example: '-rltDzvO' (don't changes owner:group of copied files,
+ * useful for vhosts than require separate group for document_root to be accessible by webserver)
+ */
+define('RSYNC_FLAGS', '-rltgoDzvO');

--- a/deploy-config.orig.php
+++ b/deploy-config.orig.php
@@ -82,3 +82,19 @@ define('EXCLUDE_FILES', serialize(array('.git')));
  * useful for vhosts than require separate group for document_root to be accessible by webserver)
  */
 define('RSYNC_FLAGS', '-rltgoDzvO');
+
+/* COMMANDS_BEFORE_RSYNC:
+ * Run commands before running rsync. Default: empty array
+ * This commands will be run under GIT_DIR after checkout from remote repository
+ * Useful for running build tasks
+ * Example: define('COMMANDS_BEFORE_RSYNC', serialize(array('composer install')));
+ */
+define('COMMANDS_BEFORE_RSYNC', serialize(array()));
+
+/* COMMANDS_AFTER_RSYNC:
+ * Run commands after running rsync. Default: empty array
+ * This commands will be run under TARGET_DIR after copying files from GIT_DIR
+ * Useful for doing some cleanups 
+ * Example: define('COMMANDS_AFTER_RSYNC', serialize(array('rm cache/*.php -f')));
+ */
+define('COMMANDS_AFTER_RSYNC', serialize(array()));

--- a/deploy-config.orig.php
+++ b/deploy-config.orig.php
@@ -98,3 +98,11 @@ define('COMMANDS_BEFORE_RSYNC', serialize(array()));
  * Example: define('COMMANDS_AFTER_RSYNC', serialize(array('rm cache/*.php -f')));
  */
 define('COMMANDS_AFTER_RSYNC', serialize(array()));
+
+/* CLEANUP_WORK_TREE:
+ * Clean GIT_DIR from leftovers after custom commands
+ * Set to true if you wish to clean up GIT_DIR after running all custom commands
+ * Useful if your custom commands create intermediate files you want not to keep between deployments
+ * However, intermediate files would not be cleaned up from TARGET_DIR
+ */
+define('CLEANUP_WORK_TREE', false);

--- a/deploy.php
+++ b/deploy.php
@@ -448,6 +448,16 @@ if(defined('COMMANDS_AFTER_RSYNC') && count(unserialize(COMMANDS_AFTER_RSYNC))) 
 	}
 }
 
+// Cleanup work tree from build results, etc
+if(defined('CLEANUP_WORK_TREE') && !empty(CLEANUP_WORK_TREE)){
+	echo "\nCleanup work tree\n";
+	cmd(sprintf(
+		'git --git-dir="%s.git" --work-tree="%s" clean -dfx'
+		, GIT_DIR
+		, GIT_DIR
+	));
+}
+
 // Update version file to current commit
 echo "\nUpdate target directory version file to commit $checkout\n";
 cmd(sprintf(

--- a/deploy.php
+++ b/deploy.php
@@ -81,6 +81,8 @@ if (!defined('BRANCH') || BRANCH === '') $err[] = 'Branch is not configured';
 if (!defined('GIT_DIR') || GIT_DIR === '') $err[] = 'Git directory is not configured';
 if (!defined('TARGET_DIR') || TARGET_DIR === '') $err[] = 'Target directory is not configured';
 if (!defined('TIME_LIMIT')) define('TIME_LIMIT', 60);
+if (!defined('EXCLUDE_FILES')) define('EXCLUDE_FILES', serialize(array('.git')));
+if (!defined('RSYNC_FLAGS')) define('RSYNC_FLAGS', '-rltgoDzvO');
 
 // If there is a configuration error
 if (count($err)) {
@@ -413,11 +415,17 @@ printf(
 );
 echo "\nNOTE: repository files that have been modfied or removed in target directory will be resynced with repository even if not listed in commits\n";
 
-// rsync all added and modified files (no deletes, exclude .git directory)
+// Build exclusion list
+$exclude = unserialize(EXCLUDE_FILES);
+array_unshift($exclude, '');
+
+// rsync all added and modified files (by default: no deletes, exclude .git directory)
 cmd(sprintf(
-	'rsync -rltgoDzvO %s %s --exclude=.git'
+	'rsync %s %s %s %s'
+	, RSYNC_FLAGS
 	, GIT_DIR
 	, TARGET_DIR
+	, implode(' --exclude=', $exclude)
 ));
 echo "\nDeleting files removed from repository\n";
 


### PR DESCRIPTION
These options are useful if you want to push source files and build project (or part of project):

- ```EXCLUDE_FILES``` - specify which files should not to be copied to ```TARGET_DIR``` (usually source files, composer.json, etc. By default: .git)

- ```RSYNC_FLAGS``` - specify rsync flags without modifying deploy.php (useful if your ```TARGET_DIR``` should keep certain owner:group, but rsync resets them)

- ```COMMANDS_BEFORE_RSYNC``` - run certain commands under ```GIT_DIR``` between pulling updates from remote repo and doing rsync (```composer install```, ```webpack```, etc)

- ```COMMANDS_AFTER_RSYNC``` - run certain commands under ```TARGET_DIR``` after doing rsync (this can be ```rm cache/*.php -f``` for example)

- ```CLEANUP_WORK_TREE``` - clean up ```GIT_DIR``` repo work tree after running all custom commands, resetting it to clean state (set to ```true``` it if you wish intermediate files not to survive between builds, does not affect ```TARGET_DIR``` content at all)

All these new options do not affect older config files. If they are missing in config, new functionality will be just ignored or set to default values (like hardcoded in old deploy.php).
