### PR TITLE
Fixed not existing getallheaders() on PHP-FPM

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -164,6 +164,18 @@ h2, .error { color: #c33; }
 // The branch
 $branch = '';
 
+if (!function_exists('getallheaders')) {
+    function getallheaders() {
+		$headers = [];
+		foreach ($_SERVER as $name => $value) {
+			if (substr($name, 0, 5) == 'HTTP_') {
+				$headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+			}
+		}
+		return $headers;
+    }
+}
+
 // Process request headers
 $headers = getallheaders();
 if(isset($headers['X-Event-Key'])) {


### PR DESCRIPTION
On php-fpm the function getallheaders() does not exist and throws a fatal error, this patch fixes that.

Snippet credit: https://web.archive.org/web/20181105214359/https://www.popmartian.com/tipsntricks/2015/07/14/howto-use-php-getallheaders-under-fastcgi-php-fpm-nginx-etc/