### PR TITLE
Fix getallheaders function polyfill to respect proper X-GitHub-* headers casing

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -205,9 +205,18 @@ $branch = '';
 if (!function_exists('getallheaders')) {
 	function getallheaders() {
 		$headers = [];
+		if (isset($_SERVER['CONTENT_TYPE']))
+			$headers['Content-Type'] = $_SERVER['CONTENT_TYPE'];
+		if (isset($_SERVER['CONTENT_LENGTH']))
+			$headers['Content-Length'] = $_SERVER['CONTENT_LENGTH'];
 		foreach ($_SERVER as $name => $value) {
 			if (substr($name, 0, 5) == 'HTTP_') {
-				$headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+				$name = substr($name, 5);
+				$name = str_replace('_', ' ', $name);
+				$name = ucwords(strtolower($name));
+				$name = str_replace(' ', '-', $name);
+				$name = str_replace('X-Github', 'X-GitHub', $name);
+				$headers[$name] = $value;
 			}
 		}
 		return $headers;


### PR DESCRIPTION
In function getallheaders() polyfill done by #5 there was a bug - it converted X-GitHub-Event header as X-Github-Event (because header names are uppercase in $_SERVER array).

Fixed this function to respect correct case for X-GitHub-* headers, which have camel case that were lost in getallheaders polyfill, so the script never respected X-GitHub-Event header when worked under PHP-FPM.

Also, refactored line a bit for better readability.

Plus added missing Content-Type, Content-Length headers which are stored without HTTP_ prefix in $_SERVER array.